### PR TITLE
Fix missing perf_data on str numbers

### DIFF
--- a/plugnpy/metric.py
+++ b/plugnpy/metric.py
@@ -116,8 +116,9 @@ class Metric(object):
             raise Exception("Invalid value for performance data precision '{0}': {1}".format(perf_data_precision, ex))
         try:
             self.value = float(self.value)
-            self.perf_data = Metric.calculate_perf_data(name, value, unit, warning_threshold, critical_threshold,
-                                                        precision=self.perf_data_precision)
+            self.perf_data = Metric.calculate_perf_data(
+                name, self.value, unit, warning_threshold, critical_threshold,
+                precision=self.perf_data_precision)
         except (ValueError, TypeError):
             self.perf_data = ''
 

--- a/test/test_metric.py
+++ b/test/test_metric.py
@@ -188,3 +188,9 @@ def test_invalid_summary_precision(value, error_msg):
     with pytest.raises(Exception) as ex:
         Metric('metric_name', 10.12345, 'B', summary_precision=value)
     assert error_msg in str(ex.value)
+
+
+def test_perf_data_type_conversion():
+    metric = Metric('metric_name', '1', 'B')
+    assert 'metric_name=1.00B' in str(metric.perf_data)
+


### PR DESCRIPTION
Performance data for metrics that are a number but have a `str` type don't show in the test output.